### PR TITLE
Pass FPSmanager size as size_t to malloc instead of u64.

### DIFF
--- a/src/sdl2_gfx/framerate.rs
+++ b/src/sdl2_gfx/framerate.rs
@@ -1,7 +1,7 @@
 //! Framerate control
 
 use libc;
-use libc::{c_void, uint32_t, malloc};
+use libc::{c_void, uint32_t, malloc, size_t};
 use std::mem;
 use sdl2::SdlResult;
 
@@ -35,7 +35,8 @@ impl FPSManager {
     /// Create the framerate manager.
     pub fn new() -> FPSManager {
         unsafe {
-            let raw = libc::malloc(mem::size_of::<ll::FPSmanager>() as u64) as *mut ll::FPSmanager;
+            let size = mem::size_of::<ll::FPSmanager>() as size_t;
+            let raw = libc::malloc(size) as *mut ll::FPSmanager;
             ll::SDL_initFramerate(raw);
             FPSManager { raw: raw }
         }


### PR DESCRIPTION
Changes the FPSmanager constructor to use the architecture dependent
size_t type from the libc crate instead of u64 as size when allocating
the memory for the instance.

Note: I'm not very versed in this kind of low-level bindings, this might be
the wrong approach. It makes it compile on my 32bit machine, but that
might not mean much
