### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ path = "src/sdl2_gfx/lib.rs"
 [dependencies]
 num = "0.1"
 libc = "0.1"
-sdl2 = "0.10"
-sdl2-sys = "0.7"
+sdl2 = "0.12"
+sdl2-sys = "0.8"
 c_vec = "1.0.*"


### PR DESCRIPTION
We need to bump version for sdl2 and sdl2-sys, as if we use old versions it will not compile with other libs that use new versions.
I've tested locally - it works fine with sdl2 v0.12.2 and sdl2-sys v0.8.0.