### PR TITLE
Update Cargo.toml: Bump sdl2 to version 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ path = "src/sdl2_gfx/lib.rs"
 [dependencies]
 num = "0.1"
 libc = "0.1"
-sdl2 = "0.12"
+sdl2 = "0.13"
 sdl2-sys = "0.8"
 c_vec = "1.0.*"


### PR DESCRIPTION
Apparently there is no version 0.12.2 anymore, so with the toml requesting 0.12, 0.12.1 was used which required sdl2-sys 0.7. That conflicted with this crate requiring sdl2-sys 0.8.

I've tested running the example after the version bump and it runs fine.