### PR TITLE
Bump dependencies and fix incompatibilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/sdl2_gfx/lib.rs"
 
 [dependencies]
 num = "0.1"
-libc = "0.1"
-sdl2 = "0.13"
+libc = "0.2"
+sdl2 = "0.16"
 sdl2-sys = "0.8"
 c_vec = "1.0.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdl2_gfx"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
 description = "SDL2_gfx bindings for Rust"
 homepage = "https://github.com/andelf/rust-sdl2_gfx"

--- a/src/sdl2_gfx/framerate.rs
+++ b/src/sdl2_gfx/framerate.rs
@@ -1,9 +1,9 @@
 //! Framerate control
 
 use libc;
-use libc::{c_void, uint32_t, malloc, size_t};
+use libc::{c_void, uint32_t, size_t};
 use std::mem;
-use sdl2::{SdlResult, ErrorMessage};
+use sdl2::get_error;
 
 
 mod ll {
@@ -44,10 +44,12 @@ impl FPSManager {
     }
 
     /// Set the framerate in Hz.
-    pub fn set_framerate(&mut self, rate: u32) -> SdlResult<()> {
+    pub fn set_framerate(&mut self, rate: u32) -> Result<(), String> {
         let ret = unsafe { ll::SDL_setFramerate(self.raw, rate as uint32_t) };
-        if ret == 0 { Ok(()) }
-        else { Err(ErrorMessage("set_framerate error: beyond lower/upper limit.".into())) }
+        match ret {
+            0 => Ok(()),
+            _ => Err(get_error())
+        }
     }
 
     /// Return the current target framerate in Hz.

--- a/src/sdl2_gfx/imagefilter.rs
+++ b/src/sdl2_gfx/imagefilter.rs
@@ -3,7 +3,7 @@
 use std::mem;
 use libc;
 use libc::{size_t, c_void, c_uint, c_int};
-use sdl2::{SdlResult, ErrorMessage};
+use sdl2::get_error;
 use c_vec::CVec;
 
 mod ll {
@@ -112,7 +112,7 @@ fn cvec_with_size(sz: usize) -> CVec<u8> {
 }
 
 /// Filter using Add: D = saturation255(S1 + S2).
-pub fn add(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn add(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -121,11 +121,11 @@ pub fn add(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                               mem::transmute(dest.get(0)),
                                               size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterAdd error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using Mean: D = S1/2 + S2/2.
-pub fn mean(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn mean(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -134,11 +134,11 @@ pub fn mean(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                mem::transmute(dest.get(0)),
                                                size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterMean error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using Sub: D = saturation0(S1 - S2).
-pub fn sub(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn sub(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -147,11 +147,11 @@ pub fn sub(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                               mem::transmute(dest.get(0)),
                                               size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterSub error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using AbsDiff: D = | S1 - S2 |.
-pub fn abs_diff(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn abs_diff(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -160,11 +160,11 @@ pub fn abs_diff(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                   mem::transmute(dest.get(0)),
                                                   size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterAbsDiff error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using Mult: D = saturation255(S1 * S2).
-pub fn mult(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn mult(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -173,11 +173,11 @@ pub fn mult(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                mem::transmute(dest.get(0)),
                                                size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterMult error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using MultNor: D = S1 * S2.
-pub fn mult_nor(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn mult_nor(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -186,11 +186,11 @@ pub fn mult_nor(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                   mem::transmute(dest.get(0)),
                                                   size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterMultNor error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using MultDivby2: D = saturation255(S1/2 * S2).
-pub fn mult_div_by2(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn mult_div_by2(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -199,11 +199,11 @@ pub fn mult_div_by2(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                      mem::transmute(dest.get(0)),
                                                      size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterMultDivby2 error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using MultDivby4: D = saturation255(S1/2 * S2/2).
-pub fn mult_div_by4(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn mult_div_by4(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -212,11 +212,11 @@ pub fn mult_div_by4(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                      mem::transmute(dest.get(0)),
                                                      size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterMultDivby4 error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using BitAnd: D = S1 & S2.
-pub fn bit_and(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn bit_and(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -225,11 +225,11 @@ pub fn bit_and(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                  mem::transmute(dest.get(0)),
                                                  size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterBitAnd error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using BitOr: D = S1 | S2.
-pub fn bit_or(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn bit_or(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -238,11 +238,11 @@ pub fn bit_or(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                                 mem::transmute(dest.get(0)),
                                                 size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterBitOr error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using Div: D = S1 / S2.
-pub fn div(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn div(src1: CVec<u8>, src2: CVec<u8>) -> Result<CVec<u8>, String> {
     assert_eq!(src1.len(), src2.len());
     let size = src1.len();
     let dest = cvec_with_size(size);
@@ -251,176 +251,176 @@ pub fn div(src1: CVec<u8>, src2: CVec<u8>) -> SdlResult<CVec<u8>> {
                                               mem::transmute(dest.get(0)),
                                               size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterDiv error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using BitNegation: D = !S.
-pub fn bit_negation(src1: CVec<u8>) -> SdlResult<CVec<u8>> {
+pub fn bit_negation(src1: CVec<u8>) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterBitNegation(mem::transmute(src1.get(0)),
                                                       mem::transmute(dest.get(0)),
                                                       size as c_uint) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterBitNegation error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using AddByte: D = saturation255(S + C).
-pub fn add_byte(src1: CVec<u8>, c: u8) -> SdlResult<CVec<u8>> {
+pub fn add_byte(src1: CVec<u8>, c: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterAddByte(mem::transmute(src1.get(0)),
                                                   mem::transmute(dest.get(0)),
                                                   size as c_uint, c) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterAddByte error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using AddUint: D = saturation255((S[i] + Cs[i % 4]), Cs=Swap32((uint)C).
-pub fn add_uint(src1: CVec<u8>, c: u32) -> SdlResult<CVec<u8>> {
+pub fn add_uint(src1: CVec<u8>, c: u32) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterAddUint(mem::transmute(src1.get(0)),
                                                   mem::transmute(dest.get(0)),
                                                   size as c_uint, c) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterAddUint error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using AddByteToHalf: D = saturation255(S/2 + C).
-pub fn add_byte_to_half(src1: CVec<u8>, c: u8) -> SdlResult<CVec<u8>> {
+pub fn add_byte_to_half(src1: CVec<u8>, c: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterAddByteToHalf(mem::transmute(src1.get(0)),
                                                         mem::transmute(dest.get(0)),
                                                         size as c_uint, c) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterAddByteToHalf error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using SubByte: D = saturation0(S - C).
-pub fn sub_byte(src1: CVec<u8>, c: u8) -> SdlResult<CVec<u8>> {
+pub fn sub_byte(src1: CVec<u8>, c: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterSubByte(mem::transmute(src1.get(0)),
                                                   mem::transmute(dest.get(0)),
                                                   size as c_uint, c) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterSubByte error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using SubUint: D = saturation0(S[i] - Cs[i % 4]), Cs=Swap32((uint)C).
-pub fn sub_uint(src1: CVec<u8>, c: u32) -> SdlResult<CVec<u8>> {
+pub fn sub_uint(src1: CVec<u8>, c: u32) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterSubUint(mem::transmute(src1.get(0)),
                                                   mem::transmute(dest.get(0)),
                                                   size as c_uint, c) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterSubUint error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using ShiftRight: D = saturation0(S >> N).
-pub fn shift_right(src1: CVec<u8>, n: u8) -> SdlResult<CVec<u8>> {
+pub fn shift_right(src1: CVec<u8>, n: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterShiftRight(mem::transmute(src1.get(0)),
                                                      mem::transmute(dest.get(0)),
                                                      size as c_uint, n) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterShiftRight error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using ShiftRightUint: D = saturation0((uint)S[i] >> N).
-pub fn shift_right_uint(src1: CVec<u8>, n: u8) -> SdlResult<CVec<u8>> {
+pub fn shift_right_uint(src1: CVec<u8>, n: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterShiftRightUint(mem::transmute(src1.get(0)),
                                                          mem::transmute(dest.get(0)),
                                                          size as c_uint, n) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterShiftRightUint error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using MultByByte: D = saturation255(S * C).
-pub fn mult_by_byte(src1: CVec<u8>, c: u8) -> SdlResult<CVec<u8>> {
+pub fn mult_by_byte(src1: CVec<u8>, c: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterMultByByte(mem::transmute(src1.get(0)),
                                                      mem::transmute(dest.get(0)),
                                                      size as c_uint, c) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterMultByByte error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using ShiftRightAndMultByByte: D = saturation255((S >> N) * C).
-pub fn shift_right_and_mult_by_byte(src1: CVec<u8>, n: u8, c: u8) -> SdlResult<CVec<u8>> {
+pub fn shift_right_and_mult_by_byte(src1: CVec<u8>, n: u8, c: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterShiftRightAndMultByByte(mem::transmute(src1.get(0)),
                                                                   mem::transmute(dest.get(0)),
                                                                   size as c_uint, n, c) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterShiftRightAndMultByByte error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using ShiftLeftByte: D = (S << N).
-pub fn shift_left_byte(src1: CVec<u8>, n: u8) -> SdlResult<CVec<u8>> {
+pub fn shift_left_byte(src1: CVec<u8>, n: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterShiftLeftByte(mem::transmute(src1.get(0)),
                                                         mem::transmute(dest.get(0)),
                                                         size as c_uint, n) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterShiftLeftByte error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using ShiftLeftUint: D = ((uint)S << N).
-pub fn shift_left_uint(src1: CVec<u8>, n: u8) -> SdlResult<CVec<u8>> {
+pub fn shift_left_uint(src1: CVec<u8>, n: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterShiftLeftUint(mem::transmute(src1.get(0)),
                                                         mem::transmute(dest.get(0)),
                                                         size as c_uint, n) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterShiftLeftUint error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter ShiftLeft: D = saturation255(S << N).
-pub fn shift_left(src1: CVec<u8>, n: u8) -> SdlResult<CVec<u8>> {
+pub fn shift_left(src1: CVec<u8>, n: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterShiftLeft(mem::transmute(src1.get(0)),
                                                     mem::transmute(dest.get(0)),
                                                     size as c_uint, n) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterShiftLeft error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using BinarizeUsingThreshold: D = (S >= T) ? 255:0.
-pub fn binarize_using_threshold(src1: CVec<u8>, t: u8) -> SdlResult<CVec<u8>> {
+pub fn binarize_using_threshold(src1: CVec<u8>, t: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterBinarizeUsingThreshold(mem::transmute(src1.get(0)),
                                                                  mem::transmute(dest.get(0)),
                                                                  size as c_uint, t) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterBinarizeUsingThreshold error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using ClipToRange: D = (S >= Tmin) & (S <= Tmax) S:Tmin | Tmax.
-pub fn clip_to_range(src1: CVec<u8>, tmin: u8, tmax: u8) -> SdlResult<CVec<u8>> {
+pub fn clip_to_range(src1: CVec<u8>, tmin: u8, tmax: u8) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterClipToRange(mem::transmute(src1.get(0)),
                                                       mem::transmute(dest.get(0)),
                                                       size as c_uint, tmin, tmax) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterClipToRange error".into())) }
+    else { Err(get_error()) }
 }
 
 /// Filter using NormalizeLinear: D = saturation255((Nmax - Nmin)/(Cmax - Cmin)*(S - Cmin) + Nmin).
-pub fn normalize_linear(src1: CVec<u8>, cmin: isize, cmax: isize, nmin: isize, nmax: isize) -> SdlResult<CVec<u8>> {
+pub fn normalize_linear(src1: CVec<u8>, cmin: isize, cmax: isize, nmin: isize, nmax: isize) -> Result<CVec<u8>, String> {
     let size = src1.len();
     let dest = cvec_with_size(size);
     let ret = unsafe { ll::SDL_imageFilterNormalizeLinear(mem::transmute(src1.get(0)),
@@ -429,5 +429,5 @@ pub fn normalize_linear(src1: CVec<u8>, cmin: isize, cmax: isize, nmin: isize, n
                                                           cmin as c_int, cmax as c_int,
                                                           nmin as c_int, nmax as c_int) };
     if ret == 0 { Ok(dest) }
-    else { Err(ErrorMessage("SDL_imageFilterNormalizeLinear error".into())) }
+    else { Err(get_error()) }
 }

--- a/src/sdl2_gfx/primitives.rs
+++ b/src/sdl2_gfx/primitives.rs
@@ -9,7 +9,6 @@ use sdl2::render::Renderer;
 use sdl2::surface::Surface;
 use sdl2::pixels;
 use sdl2::get_error;
-use sdl2::SdlResult;
 
 #[allow(dead_code)]
 mod ll {
@@ -241,186 +240,186 @@ impl ToColor for isize {
 
 /// For drawing with rust-sdl2 Renderer
 pub trait DrawRenderer {
-    fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> SdlResult<()>;
-    fn hline<C: ToColor>(&self, x1: i16, x2: i16, y: i16, color: C) -> SdlResult<()>;
-    fn vline<C: ToColor>(&self, x: i16, y1: i16, y2: i16, color: C) -> SdlResult<()>;
-    fn rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()>;
-    fn rounded_rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> SdlResult<()>;
-    fn box_<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()>;
-    fn rounded_box<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> SdlResult<()>;
-    fn line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()>;
-    fn aa_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()>;
-    fn thick_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, width: u8, color: C) -> SdlResult<()>;
-    fn circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> SdlResult<()>;
-    fn aa_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> SdlResult<()>;
-    fn filled_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> SdlResult<()>;
-    fn arc<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> SdlResult<()>;
-    fn ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> SdlResult<()>;
-    fn aa_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> SdlResult<()>;
-    fn filled_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> SdlResult<()>;
-    fn pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> SdlResult<()>;
-    fn filled_pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> SdlResult<()>;
-    fn trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> SdlResult<()>;
-    fn aa_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> SdlResult<()>;
-    fn filled_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> SdlResult<()>;
-    fn polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> SdlResult<()>;
-    fn aa_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> SdlResult<()>;
-    fn filled_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> SdlResult<()>;
-    fn textured_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], texture: &Surface, texture_dx: i16, texture_dy: i16, color: C) -> SdlResult<()>;
-    fn bezier<C: ToColor>(&self, vx: &[i16], vy: &[i16], s: isize, color: C) -> SdlResult<()>;
-    fn character<C: ToColor>(&self, x: i16, y: i16, c: char, color: C) -> SdlResult<()>;
-    fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> SdlResult<()>;
+    fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> Result<(), String>;
+    fn hline<C: ToColor>(&self, x1: i16, x2: i16, y: i16, color: C) -> Result<(), String>;
+    fn vline<C: ToColor>(&self, x: i16, y1: i16, y2: i16, color: C) -> Result<(), String>;
+    fn rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
+    fn rounded_rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String>;
+    fn box_<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
+    fn rounded_box<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String>;
+    fn line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
+    fn aa_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String>;
+    fn thick_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, width: u8, color: C) -> Result<(), String>;
+    fn circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String>;
+    fn aa_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String>;
+    fn filled_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String>;
+    fn arc<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String>;
+    fn ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String>;
+    fn aa_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String>;
+    fn filled_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String>;
+    fn pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String>;
+    fn filled_pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String>;
+    fn trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String>;
+    fn aa_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String>;
+    fn filled_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String>;
+    fn polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String>;
+    fn aa_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String>;
+    fn filled_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String>;
+    fn textured_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], texture: &Surface, texture_dx: i16, texture_dy: i16, color: C) -> Result<(), String>;
+    fn bezier<C: ToColor>(&self, vx: &[i16], vy: &[i16], s: isize, color: C) -> Result<(), String>;
+    fn character<C: ToColor>(&self, x: i16, y: i16, c: char, color: C) -> Result<(), String>;
+    fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> Result<(), String>;
 }
 
 impl<'a> DrawRenderer for Renderer<'a> {
-    fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> SdlResult<()> {
+    fn pixel<C: ToColor>(&self, x: i16, y: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::pixelColor(self.raw(), x, y, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn hline<C: ToColor>(&self, x1: i16, x2: i16, y: i16, color: C) -> SdlResult<()> {
+    fn hline<C: ToColor>(&self, x1: i16, x2: i16, y: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::hlineColor(self.raw(), x1, x2, y, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn vline<C: ToColor>(&self, x: i16, y1: i16, y2: i16, color: C) -> SdlResult<()> {
+    fn vline<C: ToColor>(&self, x: i16, y1: i16, y2: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::vlineColor(self.raw(), x, y1, y2, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()> {
+    fn rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::rectangleColor(self.raw(), x1, y1, x2, y2, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn rounded_rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> SdlResult<()> {
+    fn rounded_rectangle<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::roundedRectangleColor(self.raw(), x1, y1, x2, y2, rad, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn box_<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()> {
+    fn box_<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::boxColor(self.raw(), x1, y1, x2, y2, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn rounded_box<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> SdlResult<()> {
+    fn rounded_box<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, rad: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::roundedBoxColor(self.raw(), x1, y1, x2, y2, rad, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()> {
+    fn line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::lineColor(self.raw(), x1, y1, x2, y2, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn aa_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> SdlResult<()> {
+    fn aa_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::aalineColor(self.raw(), x1, y1, x2, y2, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn thick_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, width: u8, color: C) -> SdlResult<()> {
+    fn thick_line<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, width: u8, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::thickLineColor(self.raw(), x1, y1, x2, y2, width, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> SdlResult<()> {
+    fn circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::circleColor(self.raw(), x, y, rad, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn aa_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> SdlResult<()> {
+    fn aa_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::aacircleColor(self.raw(), x, y, rad, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn filled_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> SdlResult<()> {
+    fn filled_circle<C: ToColor>(&self, x: i16, y: i16, rad: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::filledCircleColor(self.raw(), x, y, rad, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn arc<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> SdlResult<()> {
+    fn arc<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::arcColor(self.raw(), x, y, rad, start, end, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> SdlResult<()> {
+    fn ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::ellipseColor(self.raw(), x, y, rx, ry, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn aa_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> SdlResult<()> {
+    fn aa_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::aaellipseColor(self.raw(), x, y, rx, ry, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn filled_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> SdlResult<()> {
+    fn filled_ellipse<C: ToColor>(&self, x: i16, y: i16, rx: i16, ry: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::filledEllipseColor(self.raw(), x, y, rx, ry, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> SdlResult<()> {
+    fn pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::pieColor(self.raw(), x, y, rad, start, end, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn filled_pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> SdlResult<()> {
+    fn filled_pie<C: ToColor>(&self, x: i16, y: i16, rad: i16, start: i16, end: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::filledPieColor(self.raw(), x, y, rad, start, end, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> SdlResult<()> {
+    fn trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::trigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn aa_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> SdlResult<()> {
+    fn aa_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::aatrigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32())
         };
         if ret == 0 { Ok(()) }
         else { Err(get_error()) }
     }
-    fn filled_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> SdlResult<()> {
+    fn filled_trigon<C: ToColor>(&self, x1: i16, y1: i16, x2: i16, y2: i16, x3: i16, y3: i16, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::filledTrigonColor(self.raw(), x1, y1, x2, y2, x3, y3, color.as_u32())
         };
@@ -428,7 +427,7 @@ impl<'a> DrawRenderer for Renderer<'a> {
         else { Err(get_error()) }
     }
     // FIXME: may we use pointer tuple?
-    fn polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> SdlResult<()> {
+    fn polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String> {
         assert_eq!(vx.len(), vy.len());
         let n = vx.len() as c_int;
         let ret = unsafe {
@@ -438,7 +437,7 @@ impl<'a> DrawRenderer for Renderer<'a> {
         else { Err(get_error()) }
     }
 
-    fn aa_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> SdlResult<()> {
+    fn aa_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String> {
         assert_eq!(vx.len(), vy.len());
         let n = vx.len() as c_int;
         let ret = unsafe {
@@ -448,7 +447,7 @@ impl<'a> DrawRenderer for Renderer<'a> {
         else { Err(get_error()) }
     }
 
-    fn filled_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> SdlResult<()> {
+    fn filled_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], color: C) -> Result<(), String> {
         assert_eq!(vx.len(), vy.len());
         let n = vx.len() as c_int;
         let ret = unsafe {
@@ -458,11 +457,11 @@ impl<'a> DrawRenderer for Renderer<'a> {
         else { Err(get_error()) }
     }
     #[allow(unused_variables)]
-    fn textured_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], texture: &Surface, texture_dx: i16, texture_dy: i16, color: C) -> SdlResult<()> {
+    fn textured_polygon<C: ToColor>(&self, vx: &[i16], vy: &[i16], texture: &Surface, texture_dx: i16, texture_dy: i16, color: C) -> Result<(), String> {
         unimplemented!()
     }
 
-    fn bezier<C: ToColor>(&self, vx: &[i16], vy: &[i16], s: isize, color: C) -> SdlResult<()> {
+    fn bezier<C: ToColor>(&self, vx: &[i16], vy: &[i16], s: isize, color: C) -> Result<(), String> {
         assert_eq!(vx.len(), vy.len());
         let n = vx.len() as c_int;
         let ret = unsafe {
@@ -472,7 +471,7 @@ impl<'a> DrawRenderer for Renderer<'a> {
         else { Err(get_error()) }
     }
 
-    fn character<C: ToColor>(&self, x: i16, y: i16, c: char, color: C) -> SdlResult<()> {
+    fn character<C: ToColor>(&self, x: i16, y: i16, c: char, color: C) -> Result<(), String> {
         let ret = unsafe {
             ll::characterColor(self.raw(), x, y, c as c_char, color.as_u32())
         };
@@ -480,7 +479,7 @@ impl<'a> DrawRenderer for Renderer<'a> {
         else { Err(get_error()) }
     }
 
-    fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> SdlResult<()> {
+    fn string<C: ToColor>(&self, x: i16, y: i16, s: &str, color: C) -> Result<(), String> {
         let ret = unsafe {
             let buf = CString::new(s).unwrap().as_bytes().as_ptr();
             ll::stringColor(self.raw(), x, y, buf as *mut i8, color.as_u32())

--- a/src/sdl2_gfx/rotozoom.rs
+++ b/src/sdl2_gfx/rotozoom.rs
@@ -2,7 +2,7 @@
 
 use libc::c_int;
 use sdl2::surface::Surface;
-use sdl2::{SdlResult, ErrorMessage};
+use sdl2::get_error;
 pub use std::f64::consts::PI;
 
 
@@ -39,64 +39,64 @@ mod ll {
 /// RotozoomSurface for work with rust-sdl2 Surface type
 pub trait RotozoomSurface {
     /// Rotates and zooms a surface and optional anti-aliasing.
-    fn rotozoom(&self, angle: f64, zoom: f64, smooth: bool) -> SdlResult<Surface>;
+    fn rotozoom(&self, angle: f64, zoom: f64, smooth: bool) -> Result<Surface, String>;
     /// Rotates and zooms a surface with different horizontal and vertival scaling factors and optional anti-aliasing.
-    fn rotozoom_xy(&self, angle: f64, zoomx: f64, zoomy: f64, smooth: bool) -> SdlResult<Surface>;
+    fn rotozoom_xy(&self, angle: f64, zoomx: f64, zoomy: f64, smooth: bool) -> Result<Surface, String>;
     /// Zoom a surface by independent horizontal and vertical factors with optional smoothing.
-    fn zoom(&self, zoomx: f64, zoomy: f64, smooth: bool) -> SdlResult<Surface>;
+    fn zoom(&self, zoomx: f64, zoomy: f64, smooth: bool) -> Result<Surface, String>;
     /// Shrink a surface by an integer ratio using averaging.
-    fn shrink(&self, factorx: isize, factory: isize) -> SdlResult<Surface>;
+    fn shrink(&self, factorx: isize, factory: isize) -> Result<Surface, String>;
     /// Rotates a 8/16/24/32 bit surface in increments of 90 degrees.
-    fn rotate_90deg(&self, turns: isize) -> SdlResult<Surface>;
+    fn rotate_90deg(&self, turns: isize) -> Result<Surface, String>;
 }
 
 impl<'a> RotozoomSurface for Surface<'a> {
-    fn rotozoom(&self, angle: f64, zoom: f64, smooth: bool) -> SdlResult<Surface> {
+    fn rotozoom(&self, angle: f64, zoom: f64, smooth: bool) -> Result<Surface, String> {
         let raw = unsafe {
             ll::rotozoomSurface(self.raw(), angle, zoom, smooth as c_int)
         };
         if (raw as *mut ()).is_null() {
-            Err(ErrorMessage("rotozoomSurface: error.".into()))
+            Err(get_error())
         } else {
             unsafe { Ok(Surface::from_ll(raw)) }
         }
     }
-    fn rotozoom_xy(&self, angle: f64, zoomx: f64, zoomy: f64, smooth: bool) -> SdlResult<Surface> {
+    fn rotozoom_xy(&self, angle: f64, zoomx: f64, zoomy: f64, smooth: bool) -> Result<Surface, String> {
         let raw = unsafe {
             ll::rotozoomSurfaceXY(self.raw(), angle, zoomx, zoomy, smooth as c_int)
         };
         if (raw as *mut ()).is_null() {
-            Err(ErrorMessage("rotozoomSurfaceXY: error.".into()))
+            Err(get_error())
         } else {
             unsafe { Ok(Surface::from_ll(raw)) }
         }
     }
-    fn zoom(&self, zoomx: f64, zoomy: f64, smooth: bool) -> SdlResult<Surface> {
+    fn zoom(&self, zoomx: f64, zoomy: f64, smooth: bool) -> Result<Surface, String> {
         let raw = unsafe {
             ll::zoomSurface(self.raw(), zoomx, zoomy, smooth as c_int)
         };
         if (raw as *mut ()).is_null() {
-            Err(ErrorMessage("zoomSurface: error.".into()))
+            Err(get_error())
         } else {
             unsafe { Ok(Surface::from_ll(raw)) }
         }
     }
-    fn shrink(&self, factorx: isize, factory: isize) -> SdlResult<Surface> {
+    fn shrink(&self, factorx: isize, factory: isize) -> Result<Surface, String> {
         let raw = unsafe {
             ll::shrinkSurface(self.raw(), factorx as c_int, factory as c_int)
         };
         if (raw as *mut ()).is_null() {
-            Err(ErrorMessage("shrinkSurface: error.".into()))
+            Err(get_error())
         } else {
             unsafe { Ok(Surface::from_ll(raw)) }
         }
     }
-    fn rotate_90deg(&self, turns: isize) -> SdlResult<Surface> {
+    fn rotate_90deg(&self, turns: isize) -> Result<Surface, String> {
         let raw = unsafe {
             ll::rotateSurface90Degrees(self.raw(), turns as c_int)
         };
         if (raw as *mut ()).is_null() {
-            Err(ErrorMessage("rotateSurface90Degrees: error.".into()))
+            Err(get_error())
         } else {
             unsafe { Ok(Surface::from_ll(raw)) }
         }


### PR DESCRIPTION
Dependencies for sdl2 and libc are updated to the most-recent version and the compilation errors caused by the deprecation of SdlResult are fixed. However, I am not certain if returning get_error() instead of a string is the correct way to do this. 

Version number is also bumped to synchronize with the versioning of the recent release of sdl2-sys and also so that crates.io can have a release that is compatible with the recent versions.

Please review. Thank you. 